### PR TITLE
removed redundant code

### DIFF
--- a/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/App/Inc/battery.h
+++ b/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/App/Inc/battery.h
@@ -7,38 +7,14 @@
 #pragma once
 
 #include "stdint.h"
-#include "stdbool.h"
-#include "adc_if.h"
+#include "stdio.h"
 #include "transmit.h"
-
+#include "stm32wlxx_hal.h"
 #include "FreeRTOS.h"
 #include "semphr.h"
+#include "main.h"
 
 extern I2C_HandleTypeDef hi2c2;
 extern SemaphoreHandle_t sem_start_battery_read;
 
 void Start_Get_Battery_Level_Task(void const *argument);
-
-/**
- * @brief Sets the battery voltages references
- *
- * @param min_vref The minimum voltage reference
- * @param max_vref The maximum voltage reference
- *
- * @return A warning may be generated if the voltage references are not within the stm board specs
- */
-Warning Set_Battery_Vref(const uint16_t min_vref, const uint16_t max_vref);
-
-/**
- * @brief Checks if the minimum and maximum voltage references are set
- *
- * @return true if vrefs are set, else false
- */
-bool Vrefs_Initialized(void);
-
-/**
- * @brief Gets the battery level
- *
- * @return The battery level, ranging from 0 (empty) to 255 (full)
- */
-uint8_t Get_Battery_Level(void);

--- a/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/App/Inc/message_format.h
+++ b/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/App/Inc/message_format.h
@@ -38,7 +38,6 @@ typedef enum InstructionSubtypes
 	ACTIVATE_MOTION_SENSOR = 0x02,
 	CHANGE_BRIGHTNESS = 0x03,
 	SEND_BATTERY_STATUS = 0x04,
-	SET_BATTERY_VREFS = 0x05,
 	SYNCHRONIZE_TIME_AND_DATE = 0x06,
 	SET_TIMESCHEDULE = 0x07,
 	SHOW_TIMETABLE = 0x08,
@@ -61,10 +60,7 @@ typedef enum ResponseWithDataSubtypes
 
 typedef enum Warnings
 {
-	NO_WARNING = 0x00,
-	MIN_VREF_BELOW_CUTOFF_BOARD = 0x50,
-	MIN_VREF_ABOVE_MAX_VDD_BOARD = 0x51,
-	MAX_VREF_ABOVE_MAX_VDD_BOARD = 0x52
+	NO_WARNING = 0x00
 } Warning;
 
 typedef enum Errors

--- a/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/App/Src/battery.c
+++ b/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/App/Src/battery.c
@@ -4,14 +4,9 @@
  *  Created on: May 9, 2025
  *      Author: Bjorn Wakker
  */
-#include <stdio.h>
 #include "battery.h"
 
 SemaphoreHandle_t sem_start_battery_read;
-
-static uint16_t battery_min_vref = 0; // Battery voltage when empty
-static uint16_t battery_max_vref = UINT16_MAX; // Battery voltage when full
-static bool vrefs_initialized = false; // Keeps track of if the voltage vrefs have been initialized
 
 void Start_Get_Battery_Level_Task(void const *argument) {
 	const uint8_t MAX17048_READ_ADDR = 0x6C;
@@ -33,52 +28,4 @@ void Start_Get_Battery_Level_Task(void const *argument) {
 		const uint8_t params[] = { SEND_BATTERY_STATUS, rx_buffer[0], rx_buffer[1]};
 		Tx_Set_Buffer(RESPONSE_OUT_WITH_DATA, RESPONDING_TO_INSTRUCTION, (const uint8_t* const)&params, sizeof(params));
 	}
-}
-
-
-Warning Set_Battery_Vref(const uint16_t min_vref, const uint16_t max_vref)
-{
-	battery_min_vref = min_vref;
-	battery_max_vref = max_vref;
-	vrefs_initialized = true;
-
-	if (min_vref < VDD_MIN) // Possibly not enough charge for the board
-	{
-		return MIN_VREF_BELOW_CUTOFF_BOARD;
-	}
-	else if (min_vref > VDD_MAX) // Inaccuracy in battery level calculation (always 0%)
-	{
-		return MIN_VREF_ABOVE_MAX_VDD_BOARD;
-	}
-	else if (max_vref > VDD_MAX) // Inaccuracy in battery level calculation (extended period of 100%, not linearly decreasing)
-	{
-		return MAX_VREF_ABOVE_MAX_VDD_BOARD;
-	}
-
-	return NO_WARNING;
-}
-
-bool Vrefs_Initialized(void)
-{
-	return vrefs_initialized;
-}
-
-uint8_t Get_Battery_Level(void)
-{
-	// Decide what to use for voltage reference
-	const uint16_t min = (battery_min_vref < VDD_MIN) ? VDD_MIN : battery_min_vref;
-	const uint16_t max = (battery_max_vref > VDD_MAX) ? VDD_MAX : battery_max_vref;
-	const uint16_t battery_level_mv = SYS_GetBatteryLevel();
-
-	if (battery_level_mv > max)
-	{
-		return UINT8_MAX;
-	}
-
-	if (battery_level_mv < min)
-	{
-		return 0;
-	}
-
-	return (((uint32_t)(battery_level_mv - min) * UINT8_MAX) / (max - min));
 }

--- a/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/App/Src/receive.c
+++ b/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/App/Src/receive.c
@@ -40,9 +40,6 @@ void Interpret_Message(const uint8_t *const buffer, const uint8_t buffer_size) {
 		case SEND_BATTERY_STATUS:
 			Handle_Send_Battery_Status_Instruction(buffer, buffer_size);
 			break;
-		case SET_BATTERY_VREFS:
-			Handle_Set_Battery_Vrefs_Instruction(buffer, buffer_size);
-			break;
 		case SYNCHRONIZE_TIME_AND_DATE:
 			Handle_Synchronize_Time_And_Date_Instruction(buffer, buffer_size);
 			break;
@@ -107,34 +104,6 @@ void Handle_Send_Battery_Status_Instruction(const uint8_t *const buffer, const u
 	APP_LOG(TS_OFF, VLEVEL_M, "Report battery state\r\n");
 	// battery task will perform the actual read, to not block the program
 	xSemaphoreGive(sem_start_battery_read);
-}
-
-void Handle_Set_Battery_Vrefs_Instruction(const uint8_t *const buffer, const uint8_t buffer_size)
-{
-	APP_LOG(TS_OFF, VLEVEL_M, "Setting battery min and max vref\r\n");
-
-	if (buffer_size < MESSAGE_MIN_BYTES + BATTERY_VREF_PARAMS_BYTE_COUNT)
-	{
-		const uint8_t params[] = { SET_BATTERY_VREFS };
-		Tx_Set_Buffer(RESPONSE_OUT, MISSING_DATA, (const uint8_t* const)&params, sizeof(params));
-		return;
-	}
-
-	const uint16_t min_vref = (buffer[PARAMETERS_START_BYTE] << 8) | buffer[PARAMETERS_START_BYTE + 1];
-	const uint16_t max_vref = (buffer[PARAMETERS_START_BYTE + 2] << 8) | buffer[PARAMETERS_START_BYTE + 3];
-
-	APP_LOG(TS_OFF, VLEVEL_M, "min: %u    max: %u\r\n", min_vref, max_vref);
-
-	Warning result = Set_Battery_Vref(min_vref, max_vref);
-
-	if (result != NO_WARNING)
-	{
-		const uint8_t params[] = { SET_BATTERY_VREFS, result };
-		Tx_Set_Buffer(RESPONSE_OUT_WITH_DATA, RESPONDING_TO_INSTRUCTION_WARNING, (const uint8_t* const)&params, sizeof(params));
-		return;
-	}
-
-	Tx_Set_Ack(SET_BATTERY_VREFS);
 }
 
 void Handle_Synchronize_Time_And_Date_Instruction(const uint8_t *const buffer, const uint8_t buffer_size)


### PR DESCRIPTION
## Beschrijving
Korte beschrijving van wat er is veranderd.

## Tests
- [x] Aanpassingen zijn getest door ontwikkelaar
- [x] Aanpassingen zijn getest door reviewer
- [x] Unit tests slagen allemaal

## Checklist
- [x] De code en comments zijn in het Engels geschreven
- [x] De code compileert zonder fouten
- [x] De code volgt de afgesproken conventies (zie hieronder)
- [x] FO is bijgewerkt (of n.v.t.)
- [x] TO is bijgewerkt (of n.v.t.)
- [x] Leeswijzer is bijgewerkt (of n.v.t.)
- [x] FO en TO zijn nagekeken door reviewer
- [x] Geen TODO's
- [x] Geen ongebruikte code

## Code conventies
- #pragma once bovenaan header bestanden
- Pascal_Snake_Case voor functienamen en methodenamen
- snake_case voor variables en code bestanden
- PascalCase voor structs en enums
- SCREAMING_SNAKE_CASE voor constanten, defines en macros
- Waar logisch, constanten, defines of macros gebruiken in plaats van magic numbers


## Opmerkingen
FO: n.v.t.
TO: 4.10 Complete uitleg verwijderd, allemaal niet meer correct.
      5.2.5 Waarschuwings codes verwijderd, allemaal ongebruikt.